### PR TITLE
feat: Generate initial Flutter project structure

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/material.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:provider/provider.dart';
+import 'providers/album_provider.dart';
+import 'screens/home_screen.dart';
+import 'services/database_service.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Hive.initFlutter();
+  await DatabaseService().init();
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return ChangeNotifierProvider(
+      create: (context) => AlbumProvider(),
+      child: MaterialApp(
+        title: 'Photo Album App',
+        theme: ThemeData(
+          primarySwatch: Colors.blue,
+        ),
+        home: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/lib/models/album.dart
+++ b/lib/models/album.dart
@@ -1,0 +1,15 @@
+import 'package:hive/hive.dart';
+import 'photo_pair.dart';
+
+part 'album.g.dart';
+
+@HiveType(typeId: 0)
+class Album extends HiveObject {
+  @HiveField(0)
+  final String name;
+
+  @HiveField(1)
+  final Map<DateTime, List<PhotoPair>> dates;
+
+  Album({required this.name, required this.dates});
+}

--- a/lib/models/photo_pair.dart
+++ b/lib/models/photo_pair.dart
@@ -1,0 +1,14 @@
+import 'package:hive/hive.dart';
+
+part 'photo_pair.g.dart';
+
+@HiveType(typeId: 1)
+class PhotoPair extends HiveObject {
+  @HiveField(0)
+  final String beforeImagePath;
+
+  @HiveField(1)
+  final String afterImagePath;
+
+  PhotoPair({required this.beforeImagePath, required this.afterImagePath});
+}

--- a/lib/providers/album_provider.dart
+++ b/lib/providers/album_provider.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/foundation.dart';
+import '../models/album.dart';
+import '../models/photo_pair.dart';
+import '../services/database_service.dart';
+
+class AlbumProvider extends ChangeNotifier {
+  final DatabaseService _databaseService = DatabaseService();
+
+  List<Album> _albums = [];
+  List<Album> get albums => _albums;
+
+  AlbumProvider() {
+    _loadAlbums();
+  }
+
+  Future<void> _loadAlbums() async {
+    _albums = _databaseService.getAllAlbums();
+    notifyListeners();
+  }
+
+  Future<void> createAlbum(String name) async {
+    final newAlbum = Album(name: name, dates: {});
+    await _databaseService.saveAlbum(newAlbum);
+    _albums.add(newAlbum);
+    notifyListeners();
+  }
+
+  Future<void> addPhotoPair({
+    required String albumName,
+    required DateTime date,
+    required String pathBefore,
+    required String pathAfter,
+  }) async {
+    final newPair = PhotoPair(beforeImagePath: pathBefore, afterImagePath: pathAfter);
+    await _databaseService.addPhotoPair(albumName, date, newPair);
+    // This requires a more complex update than just adding to the list
+    // For now, just reload all albums to reflect the change
+    await _loadAlbums();
+  }
+
+  Future<void> deletePhotoPair({
+    required String albumName,
+    required DateTime date,
+    required PhotoPair pair,
+  }) async {
+    await _databaseService.deletePhotoPair(albumName, date, pair);
+    await _loadAlbums();
+  }
+}

--- a/lib/screens/album_screen.dart
+++ b/lib/screens/album_screen.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/album.dart';
+import 'day_screen.dart';
+
+class AlbumScreen extends StatelessWidget {
+  final Album album;
+  const AlbumScreen({Key? key, required this.album}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final dates = album.dates.keys.toList()..sort((a, b) => b.compareTo(a));
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(album.name),
+      ),
+      body: ListView.builder(
+        itemCount: dates.length,
+        itemBuilder: (context, index) {
+          final date = dates[index];
+          final photoPairs = album.dates[date]!;
+          return ListTile(
+            title: Text(DateFormat.yMMMd().format(date)),
+            subtitle: Text('${photoPairs.length} pairs'),
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => DayScreen(
+                    albumName: album.name,
+                    date: date,
+                    photoPairs: photoPairs,
+                  ),
+                ),
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // For simplicity, we'll add a pair to the current date.
+          // A more robust implementation would use a date picker.
+          final today = DateTime.now();
+          // TODO: Implement image picking and adding a new pair
+        },
+        child: const Icon(Icons.add_a_photo),
+      ),
+    );
+  }
+}

--- a/lib/screens/comparison_screen.dart
+++ b/lib/screens/comparison_screen.dart
@@ -1,0 +1,22 @@
+import 'dart:io';
+import 'package:before_after/before_after.dart';
+import 'package:flutter/material.dart';
+import '../models/photo_pair.dart';
+
+class ComparisonScreen extends StatelessWidget {
+  final PhotoPair pair;
+  const ComparisonScreen({Key? key, required this.pair}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Compare'),
+      ),
+      body: BeforeAfter(
+        before: Image.file(File(pair.beforeImagePath)),
+        after: Image.file(File(pair.afterImagePath)),
+      ),
+    );
+  }
+}

--- a/lib/screens/day_screen.dart
+++ b/lib/screens/day_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../models/photo_pair.dart';
+import '../widgets/photo_pair_tile.dart';
+import 'comparison_screen.dart';
+
+class DayScreen extends StatelessWidget {
+  final String albumName;
+  final DateTime date;
+  final List<PhotoPair> photoPairs;
+
+  const DayScreen({
+    Key? key,
+    required this.albumName,
+    required this.date,
+    required this.photoPairs,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(DateFormat.yMMMd().format(date)),
+      ),
+      body: GridView.builder(
+        gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+          crossAxisCount: 3,
+          crossAxisSpacing: 4,
+          mainAxisSpacing: 4,
+        ),
+        itemCount: photoPairs.length,
+        itemBuilder: (context, index) {
+          final pair = photoPairs[index];
+          return PhotoPairTile(
+            pair: pair,
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => ComparisonScreen(pair: pair),
+                ),
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../providers/album_provider.dart';
+import '../widgets/album_card.dart';
+import 'album_screen.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Photo Albums'),
+      ),
+      body: Consumer<AlbumProvider>(
+        builder: (context, provider, child) {
+          if (provider.albums.isEmpty) {
+            return const Center(child: Text('No albums yet. Create one!'));
+          }
+          return GridView.builder(
+            gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+            ),
+            itemCount: provider.albums.length,
+            itemBuilder: (context, index) {
+              final album = provider.albums[index];
+              return AlbumCard(
+                album: album,
+                onTap: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => AlbumScreen(album: album),
+                    ),
+                  );
+                },
+              );
+            },
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () => _showCreateAlbumDialog(context),
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+
+  void _showCreateAlbumDialog(BuildContext context) {
+    final TextEditingController controller = TextEditingController();
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Create New Album'),
+          content: TextField(
+            controller: controller,
+            decoration: const InputDecoration(hintText: 'Album Name'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            TextButton(
+              onPressed: () {
+                if (controller.text.isNotEmpty) {
+                  Provider.of<AlbumProvider>(context, listen: false)
+                      .createAlbum(controller.text);
+                  Navigator.pop(context);
+                }
+              },
+              child: const Text('Create'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -1,0 +1,51 @@
+import 'package:hive/hive.dart';
+import '../models/album.dart';
+import '../models/photo_pair.dart';
+
+class DatabaseService {
+  static final DatabaseService _instance = DatabaseService._internal();
+  factory DatabaseService() => _instance;
+  DatabaseService._internal();
+
+  late Box<Album> _albumBox;
+
+  Future<void> init() async {
+    // Register adapters
+    Hive.registerAdapter(AlbumAdapter());
+    Hive.registerAdapter(PhotoPairAdapter());
+
+    // Open boxes
+    _albumBox = await Hive.openBox<Album>('albums');
+  }
+
+  Future<void> saveAlbum(Album album) async {
+    await _albumBox.put(album.name, album);
+  }
+
+  List<Album> getAllAlbums() {
+    return _albumBox.values.toList();
+  }
+
+  Future<void> addPhotoPair(String albumName, DateTime date, PhotoPair pair) async {
+    final album = _albumBox.get(albumName);
+    if (album != null) {
+      if (album.dates.containsKey(date)) {
+        album.dates[date]!.add(pair);
+      } else {
+        album.dates[date] = [pair];
+      }
+      await album.save();
+    }
+  }
+
+  Future<void> deletePhotoPair(String albumName, DateTime date, PhotoPair pair) async {
+    final album = _albumBox.get(albumName);
+    if (album != null && album.dates.containsKey(date)) {
+      album.dates[date]!.remove(pair);
+      if (album.dates[date]!.isEmpty) {
+        album.dates.remove(date);
+      }
+      await album.save();
+    }
+  }
+}

--- a/lib/services/image_service.dart
+++ b/lib/services/image_service.dart
@@ -1,0 +1,10 @@
+import 'package:image_picker/image_picker.dart';
+
+class ImageService {
+  final ImagePicker _picker = ImagePicker();
+
+  Future<String?> pickImage(ImageSource source) async {
+    final pickedFile = await _picker.pickImage(source: source);
+    return pickedFile?.path;
+  }
+}

--- a/lib/widgets/album_card.dart
+++ b/lib/widgets/album_card.dart
@@ -1,0 +1,30 @@
+import 'package:flutter/material.dart';
+import '../models/album.dart';
+
+class AlbumCard extends StatelessWidget {
+  final Album album;
+  final VoidCallback onTap;
+
+  const AlbumCard({
+    Key? key,
+    required this.album,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: Card(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.photo_album, size: 50),
+            const SizedBox(height: 8),
+            Text(album.name, style: Theme.of(context).textTheme.headline6),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/photo_pair_tile.dart
+++ b/lib/widgets/photo_pair_tile.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import '../models/photo_pair.dart';
+
+class PhotoPairTile extends StatelessWidget {
+  final PhotoPair pair;
+  final VoidCallback onTap;
+
+  const PhotoPairTile({
+    Key? key,
+    required this.pair,
+    required this.onTap,
+  }) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      child: GridTile(
+        child: Row(
+          children: [
+            Expanded(child: Image.file(File(pair.beforeImagePath), fit: BoxFit.cover)),
+            Expanded(child: Image.file(File(pair.afterImagePath), fit: BoxFit.cover)),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,40 @@
+name: fotordencian
+description: A new Flutter project.
+
+publish_to: 'none'
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=2.19.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  # State Management
+  provider: ^6.0.5
+
+  # Database
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+
+  # Image
+  image_picker: ^0.8.7+5
+  before_after: ^1.0.1
+
+  # Permissions
+  permission_handler: ^10.2.0
+
+  # Formatting
+  intl: ^0.18.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+  hive_generator: ^2.0.0
+  build_runner: ^2.3.3
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
This commit lays the foundation for the photo album application.

It includes:
- A recommended folder structure (`models`, `providers`, `screens`, `services`, `widgets`).
- Data models (`Album`, `PhotoPair`) with Hive annotations.
- Service layer skeletons (`DatabaseService`, `ImageService`).
- State management (`AlbumProvider`) using Provider.
- UI scaffolding for all screens (`HomeScreen`, `AlbumScreen`, `DayScreen`, `ComparisonScreen`) and reusable widgets (`AlbumCard`, `PhotoPairTile`).
- A `pubspec.yaml` with all the required dependencies.