### PR TITLE
Add tests for AlbumProvider create and photo pair date normalization

### DIFF
--- a/lib/providers/album_provider.dart
+++ b/lib/providers/album_provider.dart
@@ -33,7 +33,8 @@ class AlbumProvider extends ChangeNotifier {
   }) async {
     final newPair =
         PhotoPair(beforeImagePath: pathBefore, afterImagePath: pathAfter);
-    await _databaseService.addPhotoPair(albumName, date, newPair);
+    final normalizedDate = DateTime(date.year, date.month, date.day);
+    await _databaseService.addPhotoPair(albumName, normalizedDate, newPair);
     // This requires a more complex update than just adding to the list
     // For now, just reload all albums to reflect the change
     await _loadAlbums();

--- a/test/album_provider_test.dart
+++ b/test/album_provider_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:fotordencian/models/album.dart';
+import 'package:fotordencian/providers/album_provider.dart';
+import 'package:fotordencian/services/database_service.dart';
+
+void main() {
+  late AlbumProvider provider;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
+    await DatabaseService().init();
+  });
+
+  setUp(() async {
+    provider = AlbumProvider();
+    await Future.delayed(Duration.zero);
+  });
+
+  tearDown(() async {
+    await Hive.box<Album>('albums').clear();
+  });
+
+  tearDownAll(() async {
+    await Hive.box<Album>('albums').close();
+    await Hive.close();
+    await tempDir.delete(recursive: true);
+  });
+
+  test('createAlbum adds a new album to the internal list', () async {
+    expect(provider.albums, isEmpty);
+    await provider.createAlbum('My Album');
+    expect(provider.albums.length, 1);
+    expect(provider.albums.first.name, 'My Album');
+  });
+
+  test('addPhotoPair stores pair under normalized date', () async {
+    await provider.createAlbum('My Album');
+    final date = DateTime(2023, 5, 10, 15, 30);
+    await provider.addPhotoPair(
+      albumName: 'My Album',
+      date: date,
+      pathBefore: 'before.jpg',
+      pathAfter: 'after.jpg',
+    );
+
+    final album = provider.albums.firstWhere((a) => a.name == 'My Album');
+    final normalizedDate = DateTime(date.year, date.month, date.day);
+
+    expect(album.dates.containsKey(normalizedDate), isTrue);
+    expect(album.dates[normalizedDate]!.length, 1);
+    expect(album.dates.containsKey(date), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- normalize dates before saving photo pairs in `AlbumProvider`
- add `album_provider_test.dart` verifying album creation and date normalization

## Testing
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_b_689a5850eb94832084f4dcdbd85f3aec