### PR TITLE
Prevent multiple Hive adapter registrations

### DIFF
--- a/lib/services/database_service.dart
+++ b/lib/services/database_service.dart
@@ -10,9 +10,13 @@ class DatabaseService {
   late Box<Album> _albumBox;
 
   Future<void> init() async {
-    // Register adapters
-    Hive.registerAdapter(AlbumAdapter());
-    Hive.registerAdapter(PhotoPairAdapter());
+    // Register adapters only once to avoid Hive errors on hot reload
+    if (!Hive.isAdapterRegistered(AlbumAdapter().typeId)) {
+      Hive.registerAdapter(AlbumAdapter());
+    }
+    if (!Hive.isAdapterRegistered(PhotoPairAdapter().typeId)) {
+      Hive.registerAdapter(PhotoPairAdapter());
+    }
 
     // Open boxes
     _albumBox = await Hive.openBox<Album>('albums');


### PR DESCRIPTION
## Summary
- Avoid re-registering Hive type adapters during `DatabaseService` init to prevent runtime errors on hot reload

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a56afabf48320806ad75156b89a93